### PR TITLE
Fix for getDefaultOptions error

### DIFF
--- a/Form/Type/CronType.php
+++ b/Form/Type/CronType.php
@@ -46,7 +46,7 @@ class CronType extends AbstractType
      *
      * @return array The default options
      */
-    public function getDefaultOptions(array $options) {
+    public function getDefaultOptions() {
         return array(
             'data_class' => 'BCC\CronManagerBundle\Manager\Cron',
         );


### PR DESCRIPTION
The "array $options" parameter was removed from the CronType's getDefaultOptions function to comply with new Symfony's FormTypeInterface.

This was a fix for the following error:
Fatal error: Declaration of BCC\CronManagerBundle\Form\Type\CronType::getDefaultOptions() must be compatible with that of Symfony\Component\Form\FormTypeInterface::getDefaultOptions() ... 
