### PR TITLE
Add backward compatibility with Serializer.

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -132,7 +132,7 @@ class DefaultController extends Controller
         $data['file'] =  ($type == 'log') ? $cron->getLogFile(): $cron->getErrorFile();
         $data['content'] = \file_get_contents($data['file']);
 
-        $serializer = new Serializer(array(), array(new JsonEncoder()));
+        $serializer = new Serializer(array(), array('json' => new JsonEncoder()));
 
         return new Response($serializer->serialize($data, 'json'));
     }


### PR DESCRIPTION
All instances of Serializer in [Symfony/Component/Serializer/Tests/SerializerTest.php](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Serializer/Tests/SerializerTest.php) still use the format string as an array index, so I didn't think it necessary to add a test.
