### PR TITLE
getDefaultOptions parameters fixed

### DIFF
--- a/Form/Type/CronType.php
+++ b/Form/Type/CronType.php
@@ -46,7 +46,7 @@ class CronType extends AbstractType
      *
      * @return array The default options
      */
-    public function getDefaultOptions() {
+    public function getDefaultOptions(array $options) {
         return array(
             'data_class' => 'BCC\CronManagerBundle\Manager\Cron',
         );


### PR DESCRIPTION
This wrong method describe broke system with message
Fatal error: Declaration of BCC\CronManagerBundle\Form\Type\CronType::getDefaultOptions() must be compatible with that of Symfony\Component\Form\FormTypeInterface::getDefaultOptions() 

I have fixed that, please apply patch.
