### PR TITLE
Don't auto-apply the lessphp filter to all LESS files

### DIFF
--- a/Resources/config/assetic.yml
+++ b/Resources/config/assetic.yml
@@ -5,7 +5,6 @@ assetic:
             jar: %kernel.root_dir%/../vendor/bcc/cron-manager-bundle/BCC/CronManagerBundle/Resources/java/cssembed-0.4.5.jar
         lessphp:
             file: %kernel.root_dir%/../vendor/leafo/lessphp/lessc.inc.php
-            apply_to: "\.less$"
     assets:
         jquery_js:
             inputs:


### PR DESCRIPTION
We shouldn't auto apply the `lessphp` filter to all LESS files, since we don't know the layout of the parent application.

If the parent application uses LESS files but depends on a certain order for compilation (e.g. via `@import`) the blanket application of this filter could cause a compilation error (e.g. if a LESS variable used in one file is defined in another).

Since we are already explicitly specifying the filter to be used in `@bootstrap_less` we can safely remove the blanket filter application for all LESS files.
