### PR TITLE
Multiple translation catalogue entries

### DIFF
--- a/Resources/translations/BCCCronManagerBundle.de.xliff
+++ b/Resources/translations/BCCCronManagerBundle.de.xliff
@@ -119,38 +119,26 @@
         <target>Crontabelle</target>
       </trans-unit>
       <trans-unit id="30">
-        <source>Success</source>
-        <target>Erfolgreich</target>
-      </trans-unit>
-      <trans-unit id="31">
-        <source>Unknown</source>
-        <target>Unbekannt</target>
-      </trans-unit>
-      <trans-unit id="32">
-        <source>Error</source>
-        <target>Fehler</target>
-      </trans-unit>
-      <trans-unit id="33">
         <source>Command</source>
         <target>Befehl</target>
       </trans-unit>
-      <trans-unit id="34">
+      <trans-unit id="31">
         <source>success</source>
         <target>erfolgreich</target>
       </trans-unit>
-      <trans-unit id="35">
+      <trans-unit id="32">
         <source>unknown</source>
         <target>unbekannt</target>
       </trans-unit>
-      <trans-unit id="36">
+      <trans-unit id="33">
         <source>error</source>
         <target>fehler</target>
       </trans-unit>
-      <trans-unit id="37">
+      <trans-unit id="34">
         <source>Wake up</source>
         <target>Aufwachen</target>
       </trans-unit>
-      <trans-unit id="38">
+      <trans-unit id="35">
         <source>Suspend</source>
         <target>Aussetzen</target>
       </trans-unit>

--- a/Resources/translations/BCCCronManagerBundle.es.xliff
+++ b/Resources/translations/BCCCronManagerBundle.es.xliff
@@ -119,38 +119,26 @@
         <target>Tabla de crons</target>
       </trans-unit>
       <trans-unit id="30">
-        <source>Success</source>
-        <target>Éxito</target>
-      </trans-unit>
-      <trans-unit id="31">
-        <source>Unknown</source>
-        <target>Desconocido</target>
-      </trans-unit>
-      <trans-unit id="32">
-        <source>Error</source>
-        <target>Error</target>
-      </trans-unit>
-      <trans-unit id="33">
         <source>Command</source>
         <target>Comando</target>
       </trans-unit>
-      <trans-unit id="34">
+      <trans-unit id="31">
         <source>success</source>
         <target>éxito</target>
       </trans-unit>
-      <trans-unit id="35">
+      <trans-unit id="32">
         <source>unknown</source>
         <target>desconocido</target>
       </trans-unit>
-      <trans-unit id="36">
+      <trans-unit id="33">
         <source>error</source>
         <target>error</target>
       </trans-unit>
-      <trans-unit id="37">
+      <trans-unit id="34">
         <source>Wake up</source>
         <target>Depertarse</target>
       </trans-unit>
-      <trans-unit id="38">
+      <trans-unit id="35">
         <source>Suspend</source>
         <target>Suspender</target>
       </trans-unit>

--- a/Resources/translations/BCCCronManagerBundle.fr.xliff
+++ b/Resources/translations/BCCCronManagerBundle.fr.xliff
@@ -119,38 +119,26 @@
         <target>Table des crons</target>
       </trans-unit>
       <trans-unit id="30">
-        <source>Success</source>
-        <target>Succès</target>
-      </trans-unit>
-      <trans-unit id="31">
-        <source>Unknown</source>
-        <target>Inconnu</target>
-      </trans-unit>
-      <trans-unit id="32">
-        <source>Error</source>
-        <target>Erreur</target>
-      </trans-unit>
-      <trans-unit id="33">
         <source>Command</source>
         <target>Commande</target>
       </trans-unit>
-      <trans-unit id="34">
+      <trans-unit id="31">
         <source>success</source>
         <target>succès</target>
       </trans-unit>
-      <trans-unit id="35">
+      <trans-unit id="32">
         <source>unknown</source>
         <target>unconnu</target>
       </trans-unit>
-      <trans-unit id="36">
+      <trans-unit id="33">
         <source>error</source>
         <target>erreur</target>
       </trans-unit>
-      <trans-unit id="37">
+      <trans-unit id="34">
         <source>Wake up</source>
         <target>Réveiller</target>
       </trans-unit>
-      <trans-unit id="38">
+      <trans-unit id="35">
         <source>Suspend</source>
         <target>Suspendre</target>
       </trans-unit>

--- a/Resources/translations/BCCCronManagerBundle.pl.xliff
+++ b/Resources/translations/BCCCronManagerBundle.pl.xliff
@@ -119,38 +119,26 @@
         <target>Tabela zadań cron</target>
       </trans-unit>
       <trans-unit id="30">
-        <source>Success</source>
-        <target>Sukces</target>
-      </trans-unit>
-      <trans-unit id="31">
-        <source>Unknown</source>
-        <target>Nieznany</target>
-      </trans-unit>
-      <trans-unit id="32">
-        <source>Error</source>
-        <target>Błąd</target>
-      </trans-unit>
-      <trans-unit id="33">
         <source>Command</source>
         <target>Komenda</target>
       </trans-unit>
-      <trans-unit id="34">
+      <trans-unit id="31">
         <source>success</source>
         <target>sukces</target>
       </trans-unit>
-      <trans-unit id="35">
+      <trans-unit id="32">
         <source>unknown</source>
         <target>nieznany</target>
       </trans-unit>
-      <trans-unit id="36">
+      <trans-unit id="33">
         <source>error</source>
         <target>błąd</target>
       </trans-unit>
-      <trans-unit id="37">
+      <trans-unit id="34">
         <source>Wake up</source>
         <target>Uruchom</target>
       </trans-unit>
-      <trans-unit id="38">
+      <trans-unit id="35">
         <source>Suspend</source>
         <target>Zatrzymaj</target>
       </trans-unit>

--- a/Resources/translations/BCCCronManagerBundle.tr.xliff
+++ b/Resources/translations/BCCCronManagerBundle.tr.xliff
@@ -119,38 +119,26 @@
         <target>Cron tablosu</target>
       </trans-unit>
       <trans-unit id="30">
-        <source>Success</source>
-        <target>Başarılı</target>
-      </trans-unit>
-      <trans-unit id="31">
-        <source>Unknown</source>
-        <target>Bilinmiyor</target>
-      </trans-unit>
-      <trans-unit id="32">
-        <source>Error</source>
-        <target>Hata</target>
-      </trans-unit>
-      <trans-unit id="33">
         <source>Command</source>
         <target>Komut</target>
       </trans-unit>
-      <trans-unit id="34">
+      <trans-unit id="31">
         <source>success</source>
         <target>başarılı</target>
       </trans-unit>
-      <trans-unit id="35">
+      <trans-unit id="32">
         <source>unknown</source>
         <target>bilinmiyor</target>
       </trans-unit>
-      <trans-unit id="36">
+      <trans-unit id="33">
         <source>error</source>
         <target>hata</target>
       </trans-unit>
-      <trans-unit id="37">
+      <trans-unit id="34">
         <source>Wake up</source>
         <target>Uyanmak</target>
       </trans-unit>
-      <trans-unit id="38">
+      <trans-unit id="35">
         <source>Suspend</source>
         <target>Askıya almak</target>
       </trans-unit>

--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -9,7 +9,7 @@
             <div class="row">
                 <div class="span2">
                     <span class="label label-{% if cron.status == 'error' %}danger{% elseif cron.status == 'unknown' %}warning{%else%}success{% endif %}">
-                        {{ cron.status | trans({}, 'BCCCronManagerBundle') }}
+                        {{ cron.status | trans({}, 'BCCCronManagerBundle') | capitalize }}
                     </span>
                 </div>
                 <h3 class="span{% if cron.suspended %} text-muted{% endif %}">


### PR DESCRIPTION
Delete multiple translations catalogue entries for following : 
- Success
- Error
- Unknown
Keep only lower case entries, twig capitalize by himself. 