### PR TITLE
Symfony 3 compatibility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -131,6 +131,6 @@ Add the Assetic configuration file to the `imports` section of your `config.yml`
 
 ``` yml
 imports:
-    - { resource: @BCCCronManagerBundle/Resources/config/assetic.yml }
+    - { resource: "@BCCCronManagerBundle/Resources/config/assetic.yml" }
 ```
 


### PR DESCRIPTION
Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0