### PR TITLE
Fix minor issues as described in #86 and #87

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ autoload.php
 composer.phar
 composer.lock
 /nbproject/*
+.idea

--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -2,6 +2,7 @@
 
 namespace BCC\CronManagerBundle\Controller;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use \Symfony\Component\Serializer\Encoder\JsonEncoder;
 use \Symfony\Component\Serializer\Serializer;
@@ -17,17 +18,17 @@ class DefaultController extends Controller
     /**
      * Displays the current crons and a form to add a new one.
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\Response
+     * @return Response
      */
     public function indexAction()
     {
         $cm = new CronManager();
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
 
         $form = $this->createCronForm(new Cron());
 
-        return $this->render('BCCCronManagerBundle:Default:index.html.twig', array(
+        return $this->render('@BCCCronManager/Default/index.html.twig', array(
             'crons' => $cm->get(),
             'raw'   => $cm->getRaw(),
             'form'  => $form->createView(),
@@ -39,18 +40,18 @@ class DefaultController extends Controller
      *
      * @param Request $request
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\Response
+     * @return Response
      */
     public function addAction(Request $request)
     {
         $cm = new CronManager();
         $cron = new Cron();
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
         $form = $this->createCronForm($cron);
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $cm->add($cron);
             $this->addFlash('message', $cm->getOutput());
             $this->addFlash('error', $cm->getError());
@@ -58,7 +59,7 @@ class DefaultController extends Controller
             return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
         }
 
-        return $this->render('BCCCronManagerBundle:Default:index.html.twig', array(
+        return $this->render('@BCCCronManager/Default/index.html.twig', array(
             'crons' => $cm->get(),
             'raw'   => $cm->getRaw(),
             'form'  => $form->createView(),
@@ -68,21 +69,22 @@ class DefaultController extends Controller
     /**
      * Edit a cron
      *
-     * @param $id The line of the cron in the cron table
+     * $id The line of the cron in the cron table
+     * @param $id       
      * @param Request $request
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\RedirectResponse|\Symfony\Bundle\FrameworkBundle\Controller\Response
+     * @return RedirectResponse|Response
      */
     public function editAction($id, Request $request)
     {
         $cm = new CronManager();
         $crons = $cm->get();
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
         $form = $this->createCronForm($crons[$id]);
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $cm->write();
 
             $this->addFlash('message', $cm->getOutput());
@@ -91,7 +93,7 @@ class DefaultController extends Controller
             return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
         }
 
-        return $this->render('BCCCronManagerBundle:Default:edit.html.twig', array(
+        return $this->render('@BCCCronManager/Default/edit.html.twig', array(
             'form'  => $form->createView(),
         ));
     }
@@ -99,19 +101,19 @@ class DefaultController extends Controller
     /**
      * Wake up a cron from the cron table
      *
-     * @param $id The line of the cron in the cron table
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\RedirectResponse
+     * @param $id
+     * @return RedirectResponse
      */
     public function wakeupAction($id)
     {
         $cm = new CronManager();
         $crons = $cm->get();
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
         $crons[$id]->setSuspended(false);
         $cm->write();
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
 
         return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
     }
@@ -119,19 +121,19 @@ class DefaultController extends Controller
     /**
      * Suspend a cron from the cron table
      *
-     * @param $id The line of the cron in the cron table
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\RedirectResponse
+     * @param $id
+     * @return RedirectResponse
      */
     public function suspendAction($id)
     {
         $cm = new CronManager();
         $crons = $cm->get();
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
         $crons[$id]->setSuspended(true);
         $cm->write();
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
 
         return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
     }
@@ -139,19 +141,19 @@ class DefaultController extends Controller
     /**
      * Remove a cron from the cron table
      *
-     * @param $id The line of the cron in the cron table
+     * @param $id
      * @param Request $request
      *
-     * @return \Symfony\Bundle\FrameworkBundle\Controller\RedirectResponse
+     * @return RedirectResponse
      */
     public function removeAction($id, Request $request)
     {
         $cm = new CronManager();
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
         $cm->remove($id);
-        $this->addFlash('message', $cm->getOutput());
-        $this->addFlash('error', $cm->getError());
+        if ( $cm->getOutput() != "" ) { $this->addFlash('message', $cm->getOutput()); }
+        if ( $cm->getError() != "" ) { $this->addFlash('error', $cm->getError()); }
 
         return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
     }
@@ -159,9 +161,9 @@ class DefaultController extends Controller
     /**
      * Gets a log file
      *
-     * @param $id The line of the cron in the cron table
-     * @param $type The type of file, log or error
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @param $id
+     * @param $type
+     * @return Response
      */
     public function fileAction($id, $type)
     {

--- a/Form/Type/CronType.php
+++ b/Form/Type/CronType.php
@@ -5,7 +5,6 @@ namespace BCC\CronManagerBundle\Form\Type;
 use \Symfony\Component\Form\FormBuilderInterface;
 use \Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class CronType extends AbstractType
 {
@@ -35,7 +34,7 @@ class CronType extends AbstractType
             ));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function setDefaultOptions(OptionsResolver $resolver)
     {
         $this->configureOptions($resolver);
     }

--- a/Manager/CronManager.php
+++ b/Manager/CronManager.php
@@ -80,7 +80,7 @@ class CronManager
     /**
      * Remove a cron from the cron table
      *
-     * @param $index The line number
+     * @param $index
      */
     public function remove($index)
     {

--- a/Manager/CronManager.php
+++ b/Manager/CronManager.php
@@ -27,7 +27,7 @@ class CronManager
      *
      * @var string
      */
-    protected $output;
+    protected $output = 0;
 
     function __construct()
     {

--- a/Manager/CronManager.php
+++ b/Manager/CronManager.php
@@ -27,7 +27,7 @@ class CronManager
      *
      * @var string
      */
-    protected $output = 0;
+    protected $output = "";
 
     function __construct()
     {

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,7 +8,7 @@
         <service id="bcc_cron_manager.twig.extension" class="BCC\CronManagerBundle\Twig\TwigExtension" public="false">
             <tag name="twig.extension"/>
             <argument>%kernel.logs_dir%</argument>
-            <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.project_dir%</argument>
         </service>
     </services>
 

--- a/Resources/views/Default/edit.html.twig
+++ b/Resources/views/Default/edit.html.twig
@@ -1,4 +1,4 @@
-{% extends 'BCCCronManagerBundle::layout.html.twig' %}
+{% extends '@BCCCronManager/layout.html.twig' %}
 
 {% block content %}
     <section id="edit-cron">
@@ -6,7 +6,7 @@
             <h1>{{ 'Edit a cron' | trans({}, 'BCCCronManagerBundle') }}</h1>
         </div>
         <form role="form" method="post" action="#">
-            {% include 'BCCCronManagerBundle:Default:form.html.twig' with {'form': form} %}
+            {% include '@BCCCronManager/Default/form.html.twig' with {'form': form} %}
             <input type="submit" class="btn btn-success btn-lg" value="{{ 'Edit' | trans({}, 'BCCCronManagerBundle') }}"/>
         </form>
     </section>

--- a/Resources/views/Default/form.html.twig
+++ b/Resources/views/Default/form.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form 'BCCCronManagerBundle:Form:fields.html.twig' %}
+{% form_theme form '@BCCCronManager/Form/fields.html.twig' %}
 
 <div class="row">
     <em class="span">

--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -1,4 +1,4 @@
-{% extends 'BCCCronManagerBundle::layout.html.twig' %}
+{% extends '@BCCCronManager/layout.html.twig' %}
 
 {% block content %}
     <section id="existing-crons">
@@ -103,7 +103,7 @@
             <h2>{{ 'Add a cron' | trans({}, 'BCCCronManagerBundle') }}</h2>
         </div>
         <form role="form" method="post" action="{{ path('BCCCronManagerBundle_add') }}">
-            {% include 'BCCCronManagerBundle:Default:form.html.twig' with {'form': form} %}
+            {% include '@BCCCronManager/Default/form.html.twig' with {'form': form} %}
             <input type="submit" class="btn btn-success btn-lg" value="{{ 'Add' | trans({}, 'BCCCronManagerBundle') }}"/>
         </form>
     </section>

--- a/Twig/TwigExtension.php
+++ b/Twig/TwigExtension.php
@@ -31,7 +31,7 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
             );
         }
         $this->logDir = $logDir;
-        $this->symfonyCommand = 'php '.$kernelDir.'/console';
+        $this->symfonyCommand = 'php '.$kernelDir.'/bin/console';
     }
     
     public function getGlobals()


### PR DESCRIPTION
Fix CronManager: $output is now either an empty string ("") ilo NULL or some output from the Process. Hence the addFlash command works.

The TwigExtension has kernel.root_dir as second parameter, which is the source dir. I have replaced it with kernel.project_dir and modified the extension to "/bin/console" ilo just "/console". This way, the correct path to the console is set when clicking the pen in the form. 