### PR TITLE
Fix views paths for compatibility issues

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -56,7 +56,7 @@ class DefaultController extends Controller
             return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
         }
 
-        return $this->render('@BCCCronManager:Default:index.html.twig', array(
+        return $this->render('@BCCCronManager/Default/index.html.twig', array(
             'crons' => $cm->get(),
             'raw'   => $cm->getRaw(),
             'form'  => $form->createView(),
@@ -87,7 +87,7 @@ class DefaultController extends Controller
             return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
         }
 
-        return $this->render('@BCCCronManager:Default:edit.html.twig', array(
+        return $this->render('@BCCCronManager/Default/edit.html.twig', array(
             'form'  => $form->createView(),
         ));
     }


### PR DESCRIPTION
I get this error when i try to edit a cron:
Malformed namespaced template name "@BCCCronManager:Default:edit.html.twig" (expecting "@namespace/template_name").

I made this pull request to fix this.

bcc/cron-manager-bundle: v4.2
symfony/symfony v4.4.5