### PR TITLE
Correct namespaces for v4.2

### DIFF
--- a/Controller/DefaultController.php
+++ b/Controller/DefaultController.php
@@ -56,7 +56,7 @@ class DefaultController extends Controller
             return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
         }
 
-        return $this->render('@BCCCronManager:Default:index.html.twig', array(
+        return $this->render('@BCCCronManager/Default/index.html.twig', array(
             'crons' => $cm->get(),
             'raw'   => $cm->getRaw(),
             'form'  => $form->createView(),
@@ -87,7 +87,7 @@ class DefaultController extends Controller
             return $this->redirect($this->generateUrl('BCCCronManagerBundle_index'));
         }
 
-        return $this->render('@BCCCronManager:Default:edit.html.twig', array(
+        return $this->render('@BCCCronManager/Default/edit.html.twig', array(
             'form'  => $form->createView(),
         ));
     }

--- a/Resources/views/Default/edit.html.twig
+++ b/Resources/views/Default/edit.html.twig
@@ -6,7 +6,7 @@
             <h1>{{ 'Edit a cron' | trans({}, 'BCCCronManagerBundle') }}</h1>
         </div>
         <form role="form" method="post" action="#">
-            {% include 'BCCCronManagerBundle:Default:form.html.twig' with {'form': form} %}
+            {% include 'BCCCronManagerBundle/Default/form.html.twig' with {'form': form} %}
             <input type="submit" class="btn btn-success btn-lg" value="{{ 'Edit' | trans({}, 'BCCCronManagerBundle') }}"/>
         </form>
     </section>


### PR DESCRIPTION
Correct the namespaces for version v4.2.
See https://github.com/michelsalib/BCCCronManagerBundle/issues/99